### PR TITLE
RSDK-10260: Respond to non-service discovery dns questions. Generate the same answer as an unsolicited response during probing.

### DIFF
--- a/server.go
+++ b/server.go
@@ -470,7 +470,7 @@ func (s *Server) handleQuestion(q dns.Question, resp *dns.Msg, query *dns.Msg, i
 			resp.Answer = nil
 		}
 
-	case s.service.ServiceName():
+	case s.service.ServiceName(), s.service.NonServiceHostName():
 		s.composeBrowsingAnswers(resp, ifIndex)
 		if isKnownAnswer(resp, query) {
 			resp.Answer = nil

--- a/service.go
+++ b/service.go
@@ -117,3 +117,9 @@ func NewServiceEntry(instance, service string, domain string) *ServiceEntry {
 		ServiceRecord: *NewServiceRecord(instance, service, domain),
 	}
 }
+
+// NonServiceHostName is used for matching questions against simple `machine-name.local`
+// requests. Not for service discovery requests.
+func (s *ServiceEntry) NonServiceHostName() string {
+	return s.HostName
+}


### PR DESCRIPTION
I tested this with a go test that would require more refactoring to commit for real. First I disabled the probing part of startup:
```
diff --git i/server.go w/server.go
index 9dc800c..8b55d15 100644
--- i/server.go
+++ w/server.go
@@ -166,10 +166,10 @@ func newServerForService(entry *ServiceEntry, ifaces []net.Interface, logger gol
 
        s.service = entry
        s.startReceivers()
-       s.shutdownEnd.Add(1)
-       s.startupWait.Add(1)
-       managedGo(s.probe, s.shutdownEnd.Done)
-       s.startupWait.Wait()
+       // s.shutdownEnd.Add(1)
+       // s.startupWait.Add(1)
+       // managedGo(s.probe, s.shutdownEnd.Done)
+       // s.startupWait.Wait()
 
        return s, nil
 }
```

The probing part was the reason why mdns for `camera.local` was working for 2 minutes before dying out. Then I wrote a test like this:
```
func TestRespondToNonServiceDiscoveryRequest(t *testing.T) {
       logger := golog.NewTestLogger(t)

       cmd := exec.Command("ping", "-c", "1", "unique-name.local")
       output, err := cmd.CombinedOutput()
       if err != nil {
               fmt.Println("Error executing ping:", err)
       }
       fmt.Println(string(output))

       server, err := RegisterProxy("foo", "_rtsp._tcp", "local", 8080, "unique-name", []string{"10.1.4.196"}, []string{}, nil, logger)
       if err != nil {
               t.Fatal("Err:", err)
       }

       cmd = exec.Command("ping", "-c", "1", "unique-name.local")
       output, err = cmd.CombinedOutput()
       if err != nil {
               fmt.Println("Error executing ping:", err)
       }
       fmt.Println(string(output))
}
```

The test does two pings. One before starting the mdns server and one after. With the new code, the first ping fails, the second succeeds. In the pre-patched code, both would fail. This is how I isolated that the "long lived" part of mdns -- responding to live [m]dns lookups is working.
```
=== RUN   TestRespondToNonServiceDiscoveryRequest
Error executing ping: exit status 2
ping: unique-name.local: Name or service not known

PING unique-name.local (10.1.4.196) 56(84) bytes of data.
64 bytes from empanada (10.1.4.196): icmp_seq=1 ttl=64 time=0.056 ms

--- unique-name.local ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.056/0.056/0.056/0.000 ms
```