### PR TITLE
Bump golog dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/edaniels/golog v0.0.0-20220930140416-6e52e83a97fc
+	github.com/edaniels/golog v0.0.0-20250821172758-0d08e67686a9
 	github.com/miekg/dns v1.1.41
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6


### PR DESCRIPTION
- Bump the golog dependency to fix indirect github.com/golangci/golangci-lint dependency issues.