### PR TITLE
Remove loopback spoiling over lo interface

### DIFF
--- a/server.go
+++ b/server.go
@@ -727,11 +727,6 @@ func (s *Server) appendAddrs(list []dns.RR, ttl uint32, ifIndex int, flushCache 
 			v6 = append(v6, a6...)
 		}
 	}
-	if iface, _ := net.InterfaceByIndex(ifIndex); iface != nil {
-		if (iface.Flags & net.FlagLoopback) > 0 {
-			v4 = append(v4, net.IPv4(127, 0, 0, 1))
-		}
-	}
 	if ttl > 0 {
 		// RFC6762 Section 10 says A/AAAA records SHOULD
 		// use TTL of 120s, to account for network interface


### PR DESCRIPTION
## Description

appendAddrs() unconditionally appended 127.0.0.1 to DNS A records when the kernel delivered an mDNS multicast query via the loopback interface, poisoning hostname resolution for all clients on the machine.  

See [bug ticket ](https://viam.atlassian.net/browse/RSDK-13714)for details on how this was affecting the viamrtsp mDNS system.

```
  ┌──────────────────────────────────────────────┐ 
  │                                              │                                                    
  │  viamrtsp module                             │                                                    
  │    ├── registers: ND0125...local → 192.168.x │                                                    
  │    └── PTZ client resolves ND0125...local    │                                                    
  │              │                               │                                                    
  │         mDNS query to 224.0.0.251            │                                                    
  │              │                               │                                                    
  │         ┌────┴────┐                          │                    
  │         ▼         ▼                          │                                                    
  │       eth0       lo                          │                                                    
  │         │         │                          │
  │    ┌────┴────┐ ┌──┴──────────┐               │                                                    
  │    │response │ │response     │               │                                                    
  │    │[.x.100] │ │[.x.100,    │               │
  │    │  ✓      │ │ 127.0.0.1] │               │                                                     
  │    └────┬────┘ │  BUG ✗     │               │                                                     
  │         │      └──┬──────────┘               │                                                    
  │         └────┬────┘                          │                                                    
  │              ▼                               │                                                    
  │     resolver cache                           │                    
  │     (last response wins)                     │                                                    
  │              │                               │                                                    
  │         lo wins? → 127.0.0.1 → refused       │
  │        eth0 wins? → 192.168.x → works        │                                                    
  └──────────────────────────────────────────────┘                    
                     │                                                                                
                     ▼                                                
              Camera 192.168.x                                                                        
                                            
```

## Warning

More investigation is needed to figure out the consequences of this change. Will it break local to local discovery from processes on the same machine? 

Original [commit](https://github.com/viamrobotics/zeroconf/commit/804f4c6) that added the loopback backstop.


If a machine only has lo (no eth0, no wlan0) and uses Register() without explicit IPs, no A records will be returned.
                                                   